### PR TITLE
Fix SDL does not send UnsubscribeVehicleData request to HMI after last unregister app.

### DIFF
--- a/src/components/application_manager/include/application_manager/message_helper.h
+++ b/src/components/application_manager/include/application_manager/message_helper.h
@@ -259,6 +259,22 @@ class MessageHelper {
   static smart_objects::SmartObjectList CreateAddCommandRequestToHMI(
       ApplicationConstSharedPtr app, ApplicationManager& app_mngr);
 
+  static smart_objects::SmartObjectSPtr CreateMessageForHMI(
+      hmi_apis::messageType::eType message_type, const uint32_t correlation_id);
+
+  /**
+   * @brief Creates Message for sending to HMI for unsubscribe from specified
+   * VehicleData. Creates and returns message with vehicle data for unsubscribe.
+   * @param vehicle_data - collection with vehicle data types to unsubscribe.
+   * @param app - application which should be unsubscribed from specified
+   * vehicle data.
+   * @return - request filled with vehicle data params to unsubscribe
+   * ,application id and function id.
+   */
+  static smart_objects::SmartObjectSPtr
+  CreateUnsubscribeVehicleDataMessageForHMI(
+      const application_manager::ApplicationSharedPtr& app);
+
   static smart_objects::SmartObjectList
   CreateAddVRCommandRequestFromChoiceToHMI(ApplicationConstSharedPtr app,
                                            ApplicationManager& app_mngr);

--- a/src/components/application_manager/src/message_helper/message_helper.cc
+++ b/src/components/application_manager/src/message_helper/message_helper.cc
@@ -39,8 +39,9 @@
 #include <set>
 #include <string>
 #include <algorithm>
-#include <utility>
 #include <map>
+#include <memory>
+#include <utility>
 
 #include "application_manager/application.h"
 #include "application_manager/application_manager.h"
@@ -1061,6 +1062,47 @@ smart_objects::SmartObjectList MessageHelper::CreateAddCommandRequestToHMI(
     }
   }
   return requests;
+}
+
+smart_objects::SmartObjectSPtr MessageHelper::CreateMessageForHMI(
+    hmi_apis::messageType::eType message_type, const uint32_t correlation_id) {
+  auto message = new smart_objects::SmartObject(smart_objects::SmartType_Map);
+  auto& ref = *message;
+
+  ref[strings::params][strings::message_type] = static_cast<int>(message_type);
+  ref[strings::params][strings::protocol_version] =
+      commands::CommandImpl::protocol_version_;
+  ref[strings::params][strings::protocol_type] =
+      commands::CommandImpl::hmi_protocol_type_;
+  ref[strings::params][strings::correlation_id] = correlation_id;
+  return message;
+}
+
+smart_objects::SmartObjectSPtr
+MessageHelper::CreateUnsubscribeVehicleDataMessageForHMI(
+    const application_manager::ApplicationSharedPtr& app) {
+  auto message_to_hmi =
+      CreateMessageForHMI(hmi_apis::messageType::request, app->app_id());
+  auto vehicle_data = app->SubscribedIVI().GetData();
+  (*message_to_hmi)[strings::params][strings::function_id] =
+      hmi_apis::FunctionID::VehicleInfo_UnsubscribeVehicleData;
+  smart_objects::SmartObject msg_params =
+      smart_objects::SmartObject(smart_objects::SmartType_Map);
+  const VehicleData& v_data = MessageHelper::vehicle_data();
+
+  // This lambda puts data (as boolean) into message about needed vehicle data
+  // to unsubscribe, according to smart object keys.
+  auto vehicle_data_setter = [&msg_params, &v_data](const uint32_t v_type) {
+    for (const auto& item : v_data) {
+      if (item.second == v_type) {
+        msg_params[item.first] = true;
+      }
+    }
+  };
+
+  std::for_each(vehicle_data.begin(), vehicle_data.end(), vehicle_data_setter);
+  (*message_to_hmi)[strings::msg_params] = msg_params;
+  return message_to_hmi;
 }
 
 smart_objects::SmartObjectList

--- a/src/components/application_manager/src/mobile_command_factory.cc
+++ b/src/components/application_manager/src/mobile_command_factory.cc
@@ -143,7 +143,6 @@ CommandSharedPtr MobileCommandFactory::CreateCommand(
     commands::Command::CommandOrigin origin,
     ApplicationManager& application_manager) {
   CommandSharedPtr command;
-
   switch ((*message)[strings::params][strings::function_id].asInt()) {
     case mobile_apis::FunctionID::RegisterAppInterfaceID: {
       if ((*message)[strings::params][strings::message_type] ==


### PR DESCRIPTION
Fixes #2282

This PR is ready for review.

### Risk
This PR makes no API changes.

### Testing Plan
Covered by ATF tests.

### Summary
When each app disconnects, SDL sends to HMI UnsubscribeVehicleData request with data for unsubscribe.

### CLA
- [x] I have signed [the CLA](https://docs.google.com/forms/d/e/1FAIpQLSdsgJY33VByaX482zHzi-xUm49JNnmuJOyAM6uegPQ2LXYVfA/viewform)